### PR TITLE
Compile using Docker and GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build USBRetro Project
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build Docker image and compile for all consoles
+        run: |
+          docker build -t usbretro .
+          docker run --rm -v ${{ github.workspace }}/src/build:/root/workspace/USBRetro/src/build usbretro /bin/bash -c "sh build.sh && cd build && cmake .. && make"
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: all_console_firmwares_raspberry_pi_pico
+          path: ${{ github.workspace }}/src/build/*.uf2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build USBRetro Project
+name: Build USBRetro
 
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM docker.io/debian:bookworm-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update
+RUN apt install -y build-essential cmake git
+RUN apt install -y gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+RUN apt install -y python3 python3-pip
+RUN apt install -y vim
+RUN apt autoremove && apt clean
+
+RUN mkdir -p /root/workspace
+WORKDIR /root/workspace
+
+RUN git clone --branch 1.5.1 https://github.com/raspberrypi/pico-sdk.git
+ENV PICO_SDK_PATH=/root/workspace/pico-sdk
+WORKDIR /root/workspace/pico-sdk/lib/tinyusb
+RUN git submodule init
+RUN git submodule update
+RUN git checkout master
+
+WORKDIR /root/workspace
+RUN git clone --branch USBRETRO_V1_0_3 https://github.com/RobertDaleSmith/USBRetro.git
+WORKDIR /root/workspace/USBRetro
+RUN git submodule init
+RUN git submodule update
+
+WORKDIR /root/workspace/USBRetro/src
+RUN sh build.sh
+
+WORKDIR /root/workspace/USBRetro/src/build
+RUN cmake ..
+RUN make usbretro_ngc
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian:bookworm-slim
+FROM docker.io/debian:buster-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt install -y python3 python3-pip
 RUN apt install -y vim
 RUN apt autoremove && apt clean
 
-RUN mkdir -p /root/workspace
+RUN mkdir -p /root/workspace/USBRetro
 WORKDIR /root/workspace
 
 RUN git clone --branch 1.5.1 https://github.com/raspberrypi/pico-sdk.git
@@ -16,19 +16,13 @@ ENV PICO_SDK_PATH=/root/workspace/pico-sdk
 WORKDIR /root/workspace/pico-sdk/lib/tinyusb
 RUN git submodule init
 RUN git submodule update
-RUN git checkout master
+RUN git checkout 4b3b401ce
 
-WORKDIR /root/workspace
-RUN git clone --branch USBRETRO_V1_0_3 https://github.com/RobertDaleSmith/USBRetro.git
 WORKDIR /root/workspace/USBRetro
+COPY . .
 RUN git submodule init
 RUN git submodule update
 
 WORKDIR /root/workspace/USBRetro/src
-RUN sh build.sh
-
-WORKDIR /root/workspace/USBRetro/src/build
-RUN cmake ..
-RUN make usbretro_ngc
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
- Add a Dockerfile to reproducibly compile the project with the correct dependencies and gcc version.
- Compilation is triggered by each push to master (currently just for Raspberry Pi Pico).
- Binaries are uploaded after build via actions.
- pico-sdk version is hardcoded to the 1.5.1 tag.
- README instructions for tinyUSB state 'master' which would have been `4b3b401ce` at time of writing.