### PR TITLE
Dockerfile: use git submodule option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN git checkout 4b3b401ce
 
 WORKDIR /root/workspace/USBRetro
 COPY . .
-RUN git submodule init
-RUN git submodule update
+RUN git submodule update --init
 
 WORKDIR /root/workspace/USBRetro/src
 


### PR DESCRIPTION
👋 @bestie 

> you can also just use git submodule update --init without the explicit init step if you do not intend to customize any submodule locations.

Source: https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt-init--ltpathgt82308203