### PR TITLE
fix(nuon): corrects recently introduced spinner input issues

### DIFF
--- a/src/console/nuon/nuon.c
+++ b/src/console/nuon/nuon.c
@@ -532,6 +532,17 @@ void __not_in_flash_func(post_mouse_globals)(
   if (player_index >= 0)
   {
     players[player_index].global_buttons = buttons;
+
+    // Swap B2 and S2
+    if (!(buttons & USBR_BUTTON_B2)) {
+      players[player_index].global_buttons |= USBR_BUTTON_B2;
+      players[player_index].global_buttons &= ~USBR_BUTTON_S2;
+    }
+    if (!(buttons & USBR_BUTTON_S2)) {
+      players[player_index].global_buttons |= USBR_BUTTON_S2;
+      players[player_index].global_buttons &= ~USBR_BUTTON_B2;
+    }
+
     players[player_index].output_buttons = map_nuon_buttons(players[player_index].global_buttons & players[player_index].altern_buttons);
     players[player_index].output_analog_1x = 128;
     players[player_index].output_analog_1y = 128;

--- a/src/devices/hid_gamepad.h
+++ b/src/devices/hid_gamepad.h
@@ -11,6 +11,10 @@
 #define MAX_BUTTONS 12 // max generic HID buttons to map
 #define HID_DEBUG 1
 
+#define HID_GAMEPAD  0x00
+#define HID_MOUSE    0x01
+#define HID_KEYBOARD 0x02
+
 typedef union
 {
   struct

--- a/src/devices/hid_mouse.c
+++ b/src/devices/hid_mouse.c
@@ -79,6 +79,7 @@ void process_hid_mouse(uint8_t dev_addr, uint8_t instance, uint8_t const* mouse_
                 ((0x0000f)) | // no dpad button presses (isMouse)
                 ((report->buttons & MOUSE_BUTTON_RIGHT)   ? 0x00 : USBR_BUTTON_B1) |
                 ((report->buttons & MOUSE_BUTTON_LEFT)    ? 0x00 : USBR_BUTTON_B2) |
+                ((report->buttons & MOUSE_BUTTON_BACKWARD)? 0x00 : USBR_BUTTON_B3) |
                 ((report->buttons & MOUSE_BUTTON_FORWARD) ? 0x00 : USBR_BUTTON_S1) |
                 ((report->buttons & MOUSE_BUTTON_MIDDLE)  ? 0x00 : USBR_BUTTON_S2));
   } else {
@@ -86,6 +87,7 @@ void process_hid_mouse(uint8_t dev_addr, uint8_t instance, uint8_t const* mouse_
                 ((0x0000f)) |
                 ((report->buttons & MOUSE_BUTTON_LEFT)    ? 0x00 : USBR_BUTTON_B1) |
                 ((report->buttons & MOUSE_BUTTON_RIGHT)   ? 0x00 : USBR_BUTTON_B2) |
+                ((report->buttons & MOUSE_BUTTON_BACKWARD)? 0x00 : USBR_BUTTON_B3) |
                 ((report->buttons & MOUSE_BUTTON_FORWARD) ? 0x00 : USBR_BUTTON_S1) |
                 ((report->buttons & MOUSE_BUTTON_MIDDLE)  ? 0x00 : USBR_BUTTON_S2));
   }

--- a/src/hid_app.c
+++ b/src/hid_app.c
@@ -192,17 +192,17 @@ void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t cons
     switch (itf_protocol)
     {
       case HID_ITF_PROTOCOL_KEYBOARD:
-        TU_LOG2("HID receive boot keyboard report\r\n");
+        TU_LOG1("HID receive boot keyboard report\r\n");
         device_interfaces[CONTROLLER_KEYBOARD]->process(dev_addr, instance, report, len);
       break;
 
       case HID_ITF_PROTOCOL_MOUSE:
-        TU_LOG2("HID receive boot mouse report\r\n");
+        TU_LOG1("HID receive boot mouse report\r\n");
         device_interfaces[CONTROLLER_MOUSE]->process(dev_addr, instance, report, len);
       break;
 
       default:
-        TU_LOG2("HID receive generic report\r\n");
+        TU_LOG1("HID receive generic report\r\n");
         process_generic_report(dev_addr, instance, report, len);
       break;
     }


### PR DESCRIPTION
fix(nuon): corrects issue with some mice being detected as dinput devices and breaking Nuon spinner output.
fix(nuon): corrects two button mouse mapping to A + Start for Tempest 3000.