### PR TITLE
Changes for new tinyusb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,28 @@
-FROM docker.io/debian:buster-slim
+FROM docker.io/debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update
-RUN apt install -y build-essential cmake git
-RUN apt install -y gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
-RUN apt install -y python3 python3-pip
-RUN apt install -y vim
-RUN apt autoremove && apt clean
+RUN apt update && \
+    apt install -y --no-install-recommends \
+      build-essential \
+      cmake \
+      git \
+      gcc-arm-none-eabi \
+      libnewlib-arm-none-eabi \
+      libstdc++-arm-none-eabi-newlib \
+      python3 \
+      python3-pip \
+      vim && \
+    apt autoremove -y && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /root/workspace/USBRetro
 WORKDIR /root/workspace
 
-RUN git clone --branch 1.5.1 https://github.com/raspberrypi/pico-sdk.git
+RUN git clone https://github.com/raspberrypi/pico-sdk.git
 ENV PICO_SDK_PATH=/root/workspace/pico-sdk
-WORKDIR /root/workspace/pico-sdk/lib/tinyusb
-RUN git submodule init
-RUN git submodule update
-RUN git checkout 4b3b401ce
+WORKDIR /root/workspace/pico-sdk
+RUN git submodule update --init lib/tinyusb
 
 WORKDIR /root/workspace/USBRetro
 COPY . .

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,11 @@ add_executable(usbretro_xb1) # For the usbretro_xb1 target
 add_executable(usbretro_nuon) # For the usbretro_nuon target
 add_executable(usbretro_loopy) # For the usbretro_loopy target
 
+if (PICO_BOARD STREQUAL "pico")
+    message(STATUS "PICO_BOARD is '${PICO_BOARD}', applying RPI_PICO_BUILD definition for usbretro_pce.")
+    target_compile_definitions(usbretro_pce PRIVATE RPI_PICO_BUILD=1)
+endif()
+
 target_compile_definitions(usbretro_pce PRIVATE CONFIG_PCE=1)
 target_compile_definitions(usbretro_ngc PRIVATE CONFIG_NGC=1)
 target_compile_definitions(usbretro_xb1 PRIVATE CONFIG_XB1=1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ pico_sdk_init()
 
 set(FAMILY rp2040)
 
-#add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/tusb_xinput xinput_host)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/tusb_xinput xinput_host)
 
 add_executable(usbretro_pce) # For the usbretro_pce target
 add_executable(usbretro_ngc) # For the usbretro_ngc target
@@ -91,7 +91,7 @@ set(COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/devices/switch_pro.c
     ${CMAKE_CURRENT_SOURCE_DIR}/devices/device_utils.c
     ${CMAKE_CURRENT_SOURCE_DIR}/devices/device_registry.c
-    #${CMAKE_CURRENT_SOURCE_DIR}/xinput_app.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/xinput_app.c
     ${CMAKE_CURRENT_SOURCE_DIR}/hid_app.c
     ${CMAKE_CURRENT_SOURCE_DIR}/main.c
 )
@@ -157,7 +157,7 @@ set(COMMON_LIBRARIES
     hardware_pio
     tinyusb_host
     tinyusb_board
-    #xinput_host
+    xinput_host
 )
 
 target_link_libraries(usbretro_pce PRIVATE # FOR PCE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ pico_sdk_init()
 
 set(FAMILY rp2040)
 
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/tusb_xinput xinput_host)
+#add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/tusb_xinput xinput_host)
 
 add_executable(usbretro_pce) # For the usbretro_pce target
 add_executable(usbretro_ngc) # For the usbretro_ngc target
@@ -90,7 +90,7 @@ set(COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/devices/switch_pro.c
     ${CMAKE_CURRENT_SOURCE_DIR}/devices/device_utils.c
     ${CMAKE_CURRENT_SOURCE_DIR}/devices/device_registry.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/xinput_app.c
+    #${CMAKE_CURRENT_SOURCE_DIR}/xinput_app.c
     ${CMAKE_CURRENT_SOURCE_DIR}/hid_app.c
     ${CMAKE_CURRENT_SOURCE_DIR}/main.c
 )
@@ -156,7 +156,7 @@ set(COMMON_LIBRARIES
     hardware_pio
     tinyusb_host
     tinyusb_board
-    xinput_host
+    #xinput_host
 )
 
 target_link_libraries(usbretro_pce PRIVATE # FOR PCE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.12)
 include(pico_sdk_import.cmake)
 
 project(usbretro C CXX ASM)
+add_compile_options(-fcommon)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3") # Set optimization level to O3

--- a/src/build_rpi_pico_debug.sh
+++ b/src/build_rpi_pico_debug.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+cmake -DFAMILY=rp2040 -DBOARD=raspberry_pi_pico -DCMAKE_BUILD_TYPE=Debug -B build

--- a/src/console/pcengine/pcengine.h
+++ b/src/console/pcengine/pcengine.h
@@ -16,13 +16,22 @@
 #undef MAX_PLAYERS
 #define MAX_PLAYERS 5               // PCE supports up to 5 players
 
-// ADAFRUIT_KB2040                  // build for Adafruit KB2040 board
+// Defaults to ADAFRUIT_KB2040, build for Adafruit KB2040 board
 #define DATAIN_PIN  18
 #define CLKIN_PIN   DATAIN_PIN + 1  // Note - in pins must be a consecutive 'in' group
-#define OUTD0_PIN   26              // Note - out pins must be a consecutive 'out' group
-#define OUTD1_PIN   27
-#define OUTD2_PIN   28
-#define OUTD3_PIN   29
+
+#ifdef RPI_PICO_BUILD
+  #define OUTD0_PIN   4
+  #define OUTD1_PIN   5
+  #define OUTD2_PIN   6
+  #define OUTD3_PIN   7
+#else
+  // Default configuration
+  #define OUTD0_PIN   26 // Note - out pins must be a consecutive 'out' group
+  #define OUTD1_PIN   27
+  #define OUTD2_PIN   28
+  #define OUTD3_PIN   29
+#endif
 
 // PCE button modes
 #define BUTTON_MODE_2 0x00

--- a/src/devices/gamecube_adapter.c
+++ b/src/devices/gamecube_adapter.c
@@ -1,7 +1,7 @@
 // gamecube_adapter.c
 #include "gamecube_adapter.h"
 #include "globals.h"
-#include "bsp/board_api.h"
+#include "pico/time.h"
 
 // check if device is GameCube Adapter for WiiU/Switch
 static inline bool is_gamecube_adapter(uint16_t vid, uint16_t pid) {
@@ -131,7 +131,7 @@ void task_gamecube_adapter(uint8_t dev_addr, uint8_t instance, int player_index,
   const uint32_t interval_ms = 20;
   static uint32_t start_ms = 0;
 
-  uint32_t current_time_ms = board_millis();
+  uint32_t current_time_ms = to_ms_since_boot(get_absolute_time());
   if (current_time_ms - start_ms >= interval_ms) {
     start_ms = current_time_ms;
     output_gamecube_adapter(dev_addr, instance, player_index, rumble);

--- a/src/devices/hid_gamepad.c
+++ b/src/devices/hid_gamepad.c
@@ -1,5 +1,4 @@
 // hid_gamepad.c
-#include "bsp/board_api.h"
 #include "hid_gamepad.h"
 #include "hid_parser.h"
 #include "globals.h"

--- a/src/devices/hid_keyboard.c
+++ b/src/devices/hid_keyboard.c
@@ -1,7 +1,7 @@
 // hid_keyboard.c
 #include "hid_keyboard.h"
 #include "globals.h"
-#include "bsp/board_api.h"
+#include "pico/time.h"
 
 #ifdef CONFIG_NGC
 #define KB_ANALOG_MID 28
@@ -513,7 +513,7 @@ void task_hid_keyboard(uint8_t dev_addr, uint8_t instance, int player_index, uin
   const uint32_t interval_ms = 20;
   static uint32_t start_ms = 0;
 
-  uint32_t current_time_ms = board_millis();
+  uint32_t current_time_ms = to_ms_since_boot(get_absolute_time());
   if (current_time_ms - start_ms >= interval_ms)
   {
     start_ms = current_time_ms;

--- a/src/devices/sony_ds3.c
+++ b/src/devices/sony_ds3.c
@@ -1,7 +1,7 @@
 // sony_ds3.c
 #include "sony_ds3.h"
 #include "globals.h"
-#include "bsp/board_api.h"
+#include "pico/time.h"
 
 // DualSense instance state
 typedef struct TU_ATTR_PACKED
@@ -249,7 +249,7 @@ void task_sony_ds3(uint8_t dev_addr, uint8_t instance, int player_index, uint8_t
   const uint32_t interval_ms = 20;
   static uint32_t start_ms = 0;
 
-  uint32_t current_time_ms = board_millis();
+  uint32_t current_time_ms = to_ms_since_boot(get_absolute_time());
   if (current_time_ms - start_ms >= interval_ms) {
     start_ms = current_time_ms;
     output_sony_ds3(dev_addr, instance, player_index, rumble, leds);

--- a/src/devices/sony_ds4.c
+++ b/src/devices/sony_ds4.c
@@ -1,7 +1,7 @@
 // sony_ds4.c
 #include "sony_ds4.h"
 #include "globals.h"
-#include "bsp/board_api.h"
+#include "pico/time.h"
 
 // DualSense instance state
 typedef struct TU_ATTR_PACKED
@@ -350,7 +350,7 @@ void task_sony_ds4(uint8_t dev_addr, uint8_t instance, int player_index, uint8_t
   const uint32_t interval_ms = 20;
   static uint32_t start_ms = 0;
 
-  uint32_t current_time_ms = board_millis();
+  uint32_t current_time_ms = to_ms_since_boot(get_absolute_time());
   if (current_time_ms - start_ms >= interval_ms) {
     start_ms = current_time_ms;
     output_sony_ds4(dev_addr, instance, player_index, rumble);

--- a/src/devices/sony_ds5.c
+++ b/src/devices/sony_ds5.c
@@ -1,7 +1,7 @@
 // sony_ds5.c
 #include "sony_ds5.h"
 #include "globals.h"
-#include "bsp/board_api.h"
+#include "pico/time.h"
 
 // DualSense instance state
 typedef struct TU_ATTR_PACKED
@@ -412,7 +412,7 @@ void task_sony_ds5(uint8_t dev_addr, uint8_t instance, int player_index, uint8_t
   const uint32_t interval_ms = 20;
   static uint32_t start_ms = 0;
 
-  uint32_t current_time_ms = board_millis();
+  uint32_t current_time_ms = to_ms_since_boot(get_absolute_time());
   if (current_time_ms - start_ms >= interval_ms) {
     start_ms = current_time_ms;
     output_sony_ds5(dev_addr, instance, player_index, rumble);

--- a/src/devices/switch_pro.c
+++ b/src/devices/switch_pro.c
@@ -1,7 +1,7 @@
 // switch_pro.c
 #include "switch_pro.h"
 #include "globals.h"
-#include "bsp/board_api.h"
+#include "pico/time.h"
 
 // Switch instance state
 typedef struct TU_ATTR_PACKED
@@ -476,7 +476,7 @@ void task_switch_pro(uint8_t dev_addr, uint8_t instance, int player_index, uint8
   const uint32_t interval_ms = 20;
   static uint32_t start_ms = 0;
 
-  uint32_t current_time_ms = board_millis();
+  uint32_t current_time_ms = to_ms_since_boot(get_absolute_time());
   if (current_time_ms - start_ms >= interval_ms)
   {
     start_ms = current_time_ms;

--- a/src/main.c
+++ b/src/main.c
@@ -32,7 +32,7 @@
 
 extern void hid_app_init(void);
 extern void hid_app_task(uint8_t rumble, uint8_t leds);
-//extern void xinput_task(uint8_t rumble);
+extern void xinput_task(uint8_t rumble);
 
 extern void neopixel_init(void);
 extern void neopixel_task(int pat);
@@ -61,7 +61,7 @@ static void __not_in_flash_func(process_signals)(void)
     neopixel_task(playersCount);
 
     // xinput rumble task
-    //xinput_task(gc_rumble);
+    xinput_task(gc_rumble);
 
 #if CFG_TUH_HID
     // hid_device rumble/led task

--- a/src/main.c
+++ b/src/main.c
@@ -11,7 +11,6 @@
 #include <stdio.h>
 #include <string.h>
 
-//#include "bsp/board_api.h"
 #include "tusb.h"
 #include "pico/stdlib.h"
 #include "pico/multicore.h"

--- a/src/main.c
+++ b/src/main.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "bsp/board_api.h"
+//#include "bsp/board_api.h"
 #include "tusb.h"
 #include "pico/stdlib.h"
 #include "pico/multicore.h"
@@ -32,7 +32,7 @@
 
 extern void hid_app_init(void);
 extern void hid_app_task(uint8_t rumble, uint8_t leds);
-extern void xinput_task(uint8_t rumble);
+//extern void xinput_task(uint8_t rumble);
 
 extern void neopixel_init(void);
 extern void neopixel_task(int pat);
@@ -61,7 +61,7 @@ static void __not_in_flash_func(process_signals)(void)
     neopixel_task(playersCount);
 
     // xinput rumble task
-    xinput_task(gc_rumble);
+    //xinput_task(gc_rumble);
 
 #if CFG_TUH_HID
     // hid_device rumble/led task


### PR DESCRIPTION
This change:
* Replaces board_millis() with to_ms_since_boot(get_absolute_time()) from picom/time.h
* Removes bsp/board_api.h dependency
* Sets -fcommon build flag for pre 2.0 Raspberry Pico SDK behavior
* Changes GP26-29 to GP04-07 for the usbretro_pce build for Raspberry Pico compatibility
* Docker image is now based on Bookworm, RUN commands have been consolidated