### PR TITLE
DevEnv: Add archive package overrides to support EOL Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 FROM docker.io/debian:buster-slim
 
+# Use archived repos for EOL Debian buster
+RUN sed -i \
+    -e 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' \
+    -e 's|http://deb.debian.org/debian-security|http://archive.debian.org/debian-security|g' \
+    -e 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' \
+    /etc/apt/sources.list \
+ && printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99no-check-valid-until \
+ && apt-get -o Acquire::Check-Valid-Until=false update
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update
 RUN apt install -y build-essential cmake git


### PR DESCRIPTION
While trying to build the Devcontainer, the debian packages were not able to be fetched due to the mirrors no longer existing. The Debian buster version is now considered EOL and package repositories have been migrated to archive.debian.org.

A real fix for this is to upgrade to a later version of Debian but this is already happening with [this PR](https://github.com/RobertDaleSmith/USBRetro/pull/44). I decided to make minimal changes to unblock myself that can be updated easily once a new Debian version is updated to.